### PR TITLE
[MNT] `VARMAX` bump to pandas 2.0

### DIFF
--- a/aeon/forecasting/tests/test_varmax.py
+++ b/aeon/forecasting/tests/test_varmax.py
@@ -22,12 +22,7 @@ df = pd.DataFrame(
 
 
 @pytest.mark.skipif(
-    not all(
-        (
-            _check_soft_dependencies("statsmodels", severity="none"),
-            _check_soft_dependencies("pandas<2.0.0", severity="none"),
-        )
-    ),
+    not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_VARMAX_against_statsmodels():
@@ -55,12 +50,7 @@ def test_VARMAX_against_statsmodels():
 
 
 @pytest.mark.skipif(
-    not all(
-        (
-            _check_soft_dependencies("statsmodels", severity="none"),
-            _check_soft_dependencies("pandas<2.0.0", severity="none"),
-        )
-    ),
+    not _check_soft_dependencies("statsmodels", severity="none"),
     reason="skip test if required soft dependency not available",
 )
 def test_VARMAX_against_statsmodels_with_exog():

--- a/aeon/forecasting/varmax.py
+++ b/aeon/forecasting/varmax.py
@@ -385,7 +385,9 @@ class VARMAX(_StatsModelsAdapter):
             ):
                 y_pred.index = y_pred.index + self._y.index[0]
 
-        return y_pred.loc[fh.to_absolute(self.cutoff).to_pandas()]
+        return y_pred.loc[
+            y_pred.index.intersection(fh.to_absolute(self.cutoff).to_pandas())
+        ]
         # Can return Index Error
 
     @classmethod

--- a/aeon/forecasting/varmax.py
+++ b/aeon/forecasting/varmax.py
@@ -216,7 +216,6 @@ class VARMAX(_StatsModelsAdapter):
         "X-y-must-have-same-index": True,
         "enforce_index_type": None,
         "capability:pred_int": False,
-        "python_dependencies": "pandas<2.0.0",  # needs to be fixed with pandas==2.0.0
         # Testing with full-pytest-actions
     }
 

--- a/aeon/forecasting/varmax.py
+++ b/aeon/forecasting/varmax.py
@@ -386,6 +386,7 @@ class VARMAX(_StatsModelsAdapter):
                 y_pred.index = y_pred.index + self._y.index[0]
 
         return y_pred.loc[fh.to_absolute(self.cutoff).to_pandas()]
+        # Can return Index Error
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/aeon/forecasting/varmax.py
+++ b/aeon/forecasting/varmax.py
@@ -373,21 +373,19 @@ class VARMAX(_StatsModelsAdapter):
         # but only when out-of-sample forecasting, i.e. when forecasting horizon is
         # greater than zero
         if pd.__version__ < "2.0.0":
-            if (type(self._y.index) is pd.core.indexes.numeric.Int64Index) & (
-                any(fh.to_relative(self.cutoff) > 0)
+            if isinstance(self._y.index, pd.core.indexes.numeric.Int64Index) and any(
+                fh.to_relative(self.cutoff) > 0
             ):
-                y_pred.index = y_pred.index + self._y.index[0]
+                y_pred.index = pd.RangeIndex(start, end + 1)
         else:
             from pandas.api.types import is_any_real_numeric_dtype
 
-            if is_any_real_numeric_dtype(self._y.index) & any(
+            if is_any_real_numeric_dtype(self._y.index) and any(
                 fh.to_relative(self.cutoff) > 0
             ):
-                y_pred.index = y_pred.index + self._y.index[0]
+                y_pred.index = pd.RangeIndex(start, end + 1)
 
-        return y_pred.loc[
-            y_pred.index.intersection(fh.to_absolute(self.cutoff).to_pandas())
-        ]
+        return y_pred.loc[fh.to_absolute(self.cutoff).to_pandas()]
         # Can return Index Error
 
     @classmethod


### PR DESCRIPTION
now testing with Full-Pytest

For the sake of this PR, the `pr_pytest.yml` has been modified to test `full-pytest-actions` for the label `bug`